### PR TITLE
Shorten netlify app link to hopefully fix deploy preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo is a collection of elements, components, pages and ideas on creating t
 
 ## Live Preview (branch `main`)
 
-https://rms-design-8d69fd10-214d-46a8-a5cd-93888ceee417.netlify.app/
+https://rms-design-8d69fd10.netlify.app
 
 ## Install (after doing `git clone`)
 


### PR DESCRIPTION
Somehow the deploy preview on netlify is not working, which is a super must have feature. Maybe the subdomain name is to long (I integrated a whole UUID), therefore I shortened the subdomain.

I will look into this myself, no reviewers needed.
