### PR TITLE
Use full path for Bootstrap SCSS import

### DIFF
--- a/src/static/scss/styles.scss
+++ b/src/static/scss/styles.scss
@@ -2,7 +2,7 @@
 @import "variable_overrides";
 
 // Imported from node_modules, more infos: https://getbootstrap.com/docs/5.0/customize/sass/
-@import "bootstrap/scss/bootstrap";
+@import "node_modules/bootstrap/scss/bootstrap";
 
 // Import custom SCSS
 @import 'base/variables';


### PR DESCRIPTION
@bmlancien, please review and merge this PR. In this PR, I switched in SCSS import from an omitted path to the full `node_modules` path because the omitted path works here but not in the Django RMS code.

This change is needed because I want a foolproofed way to replace the SCSS in this repo with the SCSS in the other repo. That's why I treat the SCSS in this repo as if it would be vendor SCSS code. This way of doing stuff means if SCSS in here changes, I delete all the Bootstrap SCSS in the Django repo and paste the new code in there as a complete replacement. I do not mess with the Boostrap SCSS in the Django repo at all.

@henhuy, the above might also be an interesting side note for you!

We can think about versioning and creating NPM packages for the SCSS and JS in the future. We then can install it via NPM in the other repo and from there, thanks to some script magic, put it at the right place in the codebase.